### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/masonjing/83547b98-7e57-4092-974e-6a0e9f040b7d/57769653-5b5f-40fb-96f5-30d10c9901b7/_apis/work/boardbadge/01df0ca7-a080-494e-8827-b0d9632ecc5d)](https://dev.azure.com/masonjing/83547b98-7e57-4092-974e-6a0e9f040b7d/_boards/board/t/57769653-5b5f-40fb-96f5-30d10c9901b7/Microsoft.RequirementCategory)
 # SpringBootDemo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/masonjing/83547b98-7e57-4092-974e-6a0e9f040b7d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.